### PR TITLE
Expansion failed when wrong a record type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <name>common-records</name>
     <artifactId>common-records</artifactId>
-    <version>2.3-SNAPSHOT</version>
+    <version>2.4-SNAPSHOT</version>
 
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>dk.dbc</groupId>
         <artifactId>microservice-pom</artifactId>
-        <version>java11-old-payara5</version>
+        <version>java17-SNAPSHOT</version>
         <relativePath/>
     </parent>
 
@@ -31,6 +31,11 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-ext</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>log4j-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>

--- a/src/main/java/dk/dbc/common/records/ExpandCommonMarcRecord.java
+++ b/src/main/java/dk/dbc/common/records/ExpandCommonMarcRecord.java
@@ -245,7 +245,12 @@ public class ExpandCommonMarcRecord {
                         break;
                 }
                 if (!authRecord.hasField(hasTag(authAuthorFieldName))) {
-                    return;
+                    final DataField errorField = new DataField("e01", "00");
+                    String error = "A-post " + authRecordId + " er ikke af en type der svarer til felt " + dataField.getTag();
+                    errorField.addSubField(new SubField('a', error));
+                    expandedRecord.getFields().add(new DataField(dataField));
+                    expandedRecord.getFields().add(new DataField(errorField));
+                    continue;
                 }
                 final DataField authAuthorField = new DataField((DataField) authRecord.getField(hasTag(authAuthorFieldName)).orElseThrow());
 

--- a/src/test/java/dk/dbc/common/records/ExpandCommonMarcRecordTest.java
+++ b/src/test/java/dk/dbc/common/records/ExpandCommonMarcRecordTest.java
@@ -26,6 +26,7 @@ class ExpandCommonMarcRecordTest {
     private static final String AUT_RAW_126350333 = "authority/raw-126350333.marc";
     private static final String AUT_RAW_126850298 = "authority/raw-126850298.marc";
     private static final String AUT_RAW_22642448 = "authority/raw-22642448.marc";
+    private static final String AUT_RAW_22642448_ERROR = "authority/raw-22642448-error.marc";
     private static final String AUT_RAW_26081718 = "authority/raw-26081718.marc";
     private static final String AUT_RAW_26443784 = "authority/raw-26443784.marc";
     private static final String AUT_RAW_27568602 = "authority/raw-27568602.marc";
@@ -53,6 +54,7 @@ class ExpandCommonMarcRecordTest {
     private static final String AUT_EXPANDED_126350333 = "authority/expanded-126350333.marc";
     private static final String AUT_EXPANDED_126850298 = "authority/expanded-126850298.marc";
     private static final String AUT_EXPANDED_22642448 = "authority/expanded-22642448.marc";
+    private static final String AUT_EXPANDED_22642448_ERROR = "authority/expanded-22642448-error.marc";
     private static final String AUT_EXPANDED_26081718 = "authority/expanded-26081718.marc";
     private static final String AUT_EXPANDED_26443784 = "authority/expanded-26443784.marc";
     private static final String AUT_EXPANDED_27568602 = "authority/expanded-27568602.marc";
@@ -418,6 +420,20 @@ class ExpandCommonMarcRecordTest {
         assertThat(ExpandCommonMarcRecord.expandMarcRecord(collection, "22810804"), is(expanded));
     }
 
+    @Test
+    void textAutMus1_error() throws Exception {
+        MarcRecord expanded = loadMarcRecord(AUT_EXPANDED_22642448_ERROR);
+
+        Map<String, MarcRecord> collection = new HashMap<>();
+        collection.put("22642448", loadMarcRecord(AUT_RAW_22642448_ERROR));
+        collection.put("48872212", loadMarcRecord(AUTHORITY_48872212));
+        collection.put("48872239", loadMarcRecord(AUTHORITY_48872239));
+        collection.put("48872123", loadMarcRecord(AUTHORITY_48872123));
+        collection.put("48872336", loadMarcRecord(AUTHORITY_48872336));
+        collection.put("48872247", loadMarcRecord(AUTHORITY_48872247));
+
+        assertThat(ExpandCommonMarcRecord.expandMarcRecord(collection, "22642448"), is(expanded));
+    }
     @Test
     void textAutMus1() throws Exception {
         MarcRecord expanded = loadMarcRecord(AUT_EXPANDED_22642448);

--- a/src/test/resources/authority/expanded-22642448-error.marc
+++ b/src/test/resources/authority/expanded-22642448-error.marc
@@ -1,0 +1,32 @@
+001 00 *a 22642448 *b 870970 *c 20040121001330 *d 20030904 *f a
+004 00 *r c *a e
+008 00 *t s *u f *a 1999 *b dk *l eng *v 0
+009 00 *a s *g xc
+032 00 *a DMO199945 *x DAT200404
+039 00 *a und
+245 00 *a Irish drinking songs *e various artists
+260 00 *a [Pandrup] *b Elap *c p 1999
+300 00 *n 1 cd
+531 00 *a Indhold:
+538 00 *f Elap *g 10012622
+652 00 *m 78.797 *v 38
+666 00 *m folkemusik *m keltisk musik *m viser *m drikkeviser *n vokal *p 1900-1999 *l Irland
+770 00 *å 12 *5 870979 *6 48872336
+770 00 *å 18 *a O'Neill *h Terry
+770 00 *å 19 *A macfoley *a McFoley *h Connie
+770 00 *å 20 *a Bugge *h Camilla Toldi
+780 00 *å 13 *a Fianna Folk
+780 00 *å 15 *a Corrib Folk
+795 00 *å 12 *a The ¤fields of Athenry
+795 00 *å 13 *a Whiskey in the jar
+795 00 *å 14 *a The ¤cliffs of Dooneen *a Big strong man
+795 00 *å 15 *a Arthur McBride *a Lord of the dance *a Galway races
+795 00 *å 16 *a As I roved out
+795 00 *å 17 *a Johnston's motor car
+795 00 *å 18 *a A ¤nation once again
+795 00 *å 19 *a The ¤Galway shawl
+795 00 *å 20 *a Follow me up to Carlow
+900 00 *a Toldi Bugge *h Camilla *x se *w Bugge, Camilla Toldi *z 770/20
+910 00 *a FinFianna Folk *x se også under det senere navn *w Fianna Folk *z 780/13
+996 00 *a DBC
+e01 00 *a A-post 48872336 er ikke af en type der svarer til felt 770

--- a/src/test/resources/authority/raw-22642448-error.marc
+++ b/src/test/resources/authority/raw-22642448-error.marc
@@ -1,0 +1,29 @@
+001 00 *a 22642448 *b 870970 *c 20040121001330 *d 20030904 *f a
+004 00 *r c *a e
+008 00 *t s *u f *a 1999 *b dk *l eng *v 0
+009 00 *a s *g xc
+032 00 *a DMO199945 *x DAT200404
+039 00 *a und
+245 00 *a Irish drinking songs *e various artists
+260 00 *a [Pandrup] *b Elap *c p 1999
+300 00 *n 1 cd
+531 00 *a Indhold:
+538 00 *f Elap *g 10012622
+652 00 *m 78.797 *v 38
+666 00 *m folkemusik *m keltisk musik *m viser *m drikkeviser *n vokal *p 1900-1999 *l Irland
+770 00 *å 18 *5 870979 *6 48872212
+770 00 *å 19 *5 870979 *6 48872239
+770 00 *å 20 *5 870979 *6 48872123
+770 00 *å 12 *5 870979 *6 48872336
+780 00 *å 13 *5 870979 *6 48872247
+780 00 *å 15 *a Corrib Folk
+795 00 *å 12 *a The ¤fields of Athenry
+795 00 *å 13 *a Whiskey in the jar
+795 00 *å 14 *a The ¤cliffs of Dooneen *a Big strong man
+795 00 *å 15 *a Arthur McBride *a Lord of the dance *a Galway races
+795 00 *å 16 *a As I roved out
+795 00 *å 17 *a Johnston's motor car
+795 00 *å 18 *a A ¤nation once again
+795 00 *å 19 *a The ¤Galway shawl
+795 00 *å 20 *a Follow me up to Carlow
+996 00 *a DBC


### PR DESCRIPTION
Birger havde problemer med at der manglede 434 felt 770 når han prøvede at ekspandere post 137949318. Det er en virkelig underholdende post - kan f.eks. ikke gemmes som iso2709 i expanderet format. Sjovt nok kan record-service godt udlevere den i 2709 men der mangler det sjette ciffer i længden (der er jo kun plads til 5 😱 )